### PR TITLE
ArgoCD GUIから参照ブランチを変更できるようにする

### DIFF
--- a/k8s/services/templates/couchdb.yaml
+++ b/k8s/services/templates/couchdb.yaml
@@ -37,7 +37,7 @@ spec:
 
   - path: k8s/services/manifests/couchdb
     repoURL: {{ .Values.spec.source.repoURL }}
-    targetRevision: {{ .Values.spec.source.targetRevision }}
+    targetRevision: {{ .Values.global.charts_version }}
   syncPolicy:
     syncOptions:
     - CreateNamespace=true

--- a/k8s/services/templates/tt-rss.yaml
+++ b/k8s/services/templates/tt-rss.yaml
@@ -11,7 +11,7 @@ spec:
   sources:
   - path: k8s/services/manifests/tt-rss
     repoURL: {{ .Values.spec.source.repoURL }}
-    targetRevision: {{ .Values.spec.source.targetRevision }}
+    targetRevision: {{ .Values.global.charts_version }}
   syncPolicy:
     syncOptions:
     - CreateNamespace=true

--- a/k8s/services/values.yaml
+++ b/k8s/services/values.yaml
@@ -7,3 +7,7 @@ spec:
   source:
     repoURL: https://github.com/furon-kuina/furonverse
     targetRevision: HEAD
+    helm:
+      parameters:
+        - name: global.charts_version
+          value: $ARGOCD_APP_SOURCE_TARGET_REVISION

--- a/k8s/system/templates/argocd.yaml
+++ b/k8s/system/templates/argocd.yaml
@@ -11,7 +11,7 @@ spec:
   source:
     path: k8s/system/manifests/argocd
     repoURL: {{ .Values.spec.source.repoURL }}
-    targetRevision: {{ .Values.spec.source.targetRevision }}
+    targetRevision: {{ .Values.global.charts_version }}
   syncPolicy:
     syncOptions:
     - CreateNamespace=true

--- a/k8s/system/templates/cloudflared.yaml
+++ b/k8s/system/templates/cloudflared.yaml
@@ -11,7 +11,7 @@ spec:
   source:
     path: k8s/system/manifests/cloudflared
     repoURL: {{ .Values.spec.source.repoURL }}
-    targetRevision: {{ .Values.spec.source.targetRevision }}
+    targetRevision: {{ .Values.global.charts_version }}
   syncPolicy:
     syncOptions:
     - CreateNamespace=true

--- a/k8s/system/templates/envoy-gateway.yaml
+++ b/k8s/system/templates/envoy-gateway.yaml
@@ -18,7 +18,7 @@ spec:
       releaseName: eg
   - path: k8s/system/manifests/envoy-gateway
     repoURL: {{ .Values.spec.source.repoURL }}
-    targetRevision: {{ .Values.spec.source.targetRevision }}
+    targetRevision: {{ .Values.global.charts_version }}
   syncPolicy:
     syncOptions:
     - CreateNamespace=true

--- a/k8s/system/templates/external-secrets.yaml
+++ b/k8s/system/templates/external-secrets.yaml
@@ -14,7 +14,7 @@ spec:
     targetRevision: 0.10.7
   - path: k8s/system/manifests/external-secrets
     repoURL: {{ .Values.spec.source.repoURL }}
-    targetRevision: {{ .Values.spec.source.targetRevision }}
+    targetRevision: {{ .Values.global.charts_version }}
   syncPolicy:
     syncOptions:
     - CreateNamespace=true

--- a/k8s/system/templates/longhorn.yaml
+++ b/k8s/system/templates/longhorn.yaml
@@ -20,7 +20,7 @@ spec:
           defaultClassReplicaCount: 2
   - path: k8s/system/manifests/longhorn
     repoURL: {{ .Values.spec.source.repoURL }}
-    targetRevision: {{ .Values.spec.source.targetRevision }}
+    targetRevision: {{ .Values.global.charts_version }}
   syncPolicy:
     syncOptions:
     - CreateNamespace=true

--- a/k8s/system/templates/prometheus-stack.yaml
+++ b/k8s/system/templates/prometheus-stack.yaml
@@ -38,7 +38,7 @@ spec:
                       storage: 10Gi
   - path: k8s/system/manifests/prometheus-stack
     repoURL: {{ .Values.spec.source.repoURL }}
-    targetRevision: {{ .Values.spec.source.targetRevision }}
+    targetRevision: {{ .Values.global.charts_version }}
   syncPolicy:
     syncOptions:
     - CreateNamespace=true

--- a/k8s/system/values.yaml
+++ b/k8s/system/values.yaml
@@ -7,3 +7,7 @@ spec:
   source:
     repoURL: https://github.com/furon-kuina/furonverse
     targetRevision: HEAD
+    helm:
+      parameters:
+        - name: global.charts_version
+          value: $ARGOCD_APP_SOURCE_TARGET_REVISION


### PR DESCRIPTION
Root appがtargetRevisionをHEADに固定し、Child appsはそれをinheritしていたため、GUIではブランチをHEADから変更できない状態だった。
下記issueに従ってブランチを変更できるようにした。
https://github.com/argoproj/argo-cd/issues/20072