### PR TITLE
Add Promtail

### DIFF
--- a/k8s/system/manifests/promtail/externalsecrets.yaml
+++ b/k8s/system/manifests/promtail/externalsecrets.yaml
@@ -1,0 +1,16 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: loki-endpoint
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: gcpsm
+  target:
+    name: loki-endpoint
+  data:
+  - secretKey: loki-endpoint
+    remoteRef:
+      key: k8s
+      property: loki-endpoint

--- a/k8s/system/manifests/promtail/promtail.yaml
+++ b/k8s/system/manifests/promtail/promtail.yaml
@@ -17,7 +17,7 @@ spec:
       initContainers:
       - name: replace-loki-endpoint
         image: ubuntu:22.04
-        commands: ["bash", "-c", "sed -i /etc/promtail/promtail.yaml \"s/LOKI_ENDPOINT/foobar\""]
+        commands: ["bash", "-c", "sed -i /etc/promtail/promtail.yaml 's/LOKI_ENDPOINT/foobar'"]
         volumeMounts:
         - name: promtail-config
           mountPath: /etc/promtail

--- a/k8s/system/manifests/promtail/promtail.yaml
+++ b/k8s/system/manifests/promtail/promtail.yaml
@@ -26,6 +26,10 @@ spec:
           readOnly: true
         - name: promtail
           mountPath: /etc/promtail
+      tolerations:
+      - key: "node-role.kubernetes.io/control-plane"
+        operator: "Exists"
+        effect: "NoSchedule"
       containers:
       - name: promtail-container
         image: grafana/promtail

--- a/k8s/system/manifests/promtail/promtail.yaml
+++ b/k8s/system/manifests/promtail/promtail.yaml
@@ -17,7 +17,7 @@ spec:
       initContainers:
       - name: replace-loki-endpoint
         image: ubuntu:22.04
-        commands: ["bash", "-c", "sed -i /etc/promtail/promtail.yaml 's/LOKI_ENDPOINT/foobar'"]
+        commands: ["bash", "-c", "sed -i /etc/promtail/promtail.yaml 's/LOKI_ENDPOINT/foobar/"]
         volumeMounts:
         - name: promtail-config
           mountPath: /etc/promtail

--- a/k8s/system/manifests/promtail/promtail.yaml
+++ b/k8s/system/manifests/promtail/promtail.yaml
@@ -17,7 +17,7 @@ spec:
       initContainers:
       - name: replace-loki-endpoint
         image: ubuntu:22.04
-        commands: ["bash", "-c", "cat /etc/promtail/loki-endpoint && cat /etc/promtail/promtail.yaml && sed -i /etc/promtail \"s/LOKI_ENDPOINT/$(cat /etc/promtail/loki-endpoint)\""]
+        commands: ["bash", "-c", "cat /etc/loki/loki-endpoint && cat /etc/promtail/promtail.yaml && sed -i /etc/promtail \"s/LOKI_ENDPOINT/$(cat /etc/promtail/loki-endpoint)\""]
         volumeMounts:
         - name: promtail-config
           mountPath: /etc/promtail
@@ -42,7 +42,7 @@ spec:
         - mountPath: /var/lib/docker/containers
           name: varlibdockercontainers
           readOnly: true
-        - mountPath: /etc/promtail
+        - mountPath: /etc/loki
           name: loki-endpoint
           readOnly: true
       volumes:

--- a/k8s/system/manifests/promtail/promtail.yaml
+++ b/k8s/system/manifests/promtail/promtail.yaml
@@ -17,7 +17,7 @@ spec:
       initContainers:
       - name: replace-loki-endpoint
         image: ubuntu:22.04
-        commands: ["bash", "-c", "cat /etc/loki/loki-endpoint && cat /etc/promtail/promtail.yaml && sed -i /etc/promtail \"s/LOKI_ENDPOINT/$(cat /etc/promtail/loki-endpoint)\""]
+        commands: ["bash", "-c", "cat /etc/loki/loki-endpoint && cat /etc/promtail/promtail.yaml && sed -i /etc/promtail \"s/LOKI_ENDPOINT/$(cat /etc/loki/loki-endpoint)\""]
         volumeMounts:
         - name: promtail-config
           mountPath: /etc/promtail

--- a/k8s/system/manifests/promtail/promtail.yaml
+++ b/k8s/system/manifests/promtail/promtail.yaml
@@ -24,8 +24,8 @@ spec:
         - mountPath: /etc/loki
           name: loki-endpoint
           readOnly: true
-        - mountPath: /etc/promtail
-          name: 
+        - name: promtail
+          mountPath: /etc/promtail
       containers:
       - name: promtail-container
         image: grafana/promtail

--- a/k8s/system/manifests/promtail/promtail.yaml
+++ b/k8s/system/manifests/promtail/promtail.yaml
@@ -24,6 +24,8 @@ spec:
         - mountPath: /etc/loki
           name: loki-endpoint
           readOnly: true
+        - mountPath: /etc/promtail
+          name: 
       containers:
       - name: promtail-container
         image: grafana/promtail
@@ -45,6 +47,8 @@ spec:
         - mountPath: /etc/loki
           name: loki-endpoint
           readOnly: true
+        - name: promtail
+          mountPath: /etc/promtail
       volumes:
       - name: logs
         hostPath:
@@ -58,6 +62,8 @@ spec:
       - name: loki-endpoint
         secret:
           secretName: loki-endpoint
+      - name: promtail
+        emptyDir: {} 
 --- # configmap.yaml
 apiVersion: v1
 kind: ConfigMap

--- a/k8s/system/manifests/promtail/promtail.yaml
+++ b/k8s/system/manifests/promtail/promtail.yaml
@@ -17,7 +17,7 @@ spec:
       initContainers:
       - name: replace-loki-endpoint
         image: ubuntu:22.04
-        commands: ["bash", "-c", "mkdir /etc/promtail && touch /etc/promtail/promtail.yaml && sed \"s/LOKI_ENDPOINT/$(cat /etc/loki/loki-endpoint)/\" /etc/setup/promtail.yaml > /etc/promtail/promtail.yaml"]
+        commands: ["bash", "-c", "touch /etc/promtail/promtail.yaml && ls /etc/loki && ls /etc/setup && ls /etc/promtail && sed \"s/LOKI_ENDPOINT/$(cat /etc/loki/loki-endpoint)/\" /etc/setup/promtail.yaml > /etc/promtail/promtail.yaml"]
         volumeMounts:
         - name: promtail-config
           mountPath: /etc/setup

--- a/k8s/system/manifests/promtail/promtail.yaml
+++ b/k8s/system/manifests/promtail/promtail.yaml
@@ -17,7 +17,7 @@ spec:
       initContainers:
       - name: replace-loki-endpoint
         image: ubuntu:22.04
-        commands: ["bash", "-c", "cat /etc/loki/loki-endpoint && cat /etc/promtail/promtail.yaml && sed -i /etc/promtail/promtail.yaml \"s/LOKI_ENDPOINT/$(cat /etc/loki/loki-endpoint)\""]
+        commands: ["bash", "-c", "sed -i /etc/promtail/promtail.yaml \"s/LOKI_ENDPOINT/foobar\""]
         volumeMounts:
         - name: promtail-config
           mountPath: /etc/promtail

--- a/k8s/system/manifests/promtail/promtail.yaml
+++ b/k8s/system/manifests/promtail/promtail.yaml
@@ -21,7 +21,7 @@ spec:
         volumeMounts:
         - name: promtail-config
           mountPath: /etc/promtail
-        - mountPath: /etc/promtail
+        - mountPath: /etc/loki
           name: loki-endpoint
           readOnly: true
       containers:

--- a/k8s/system/manifests/promtail/promtail.yaml
+++ b/k8s/system/manifests/promtail/promtail.yaml
@@ -1,0 +1,151 @@
+# copied from https://grafana.com/docs/loki/latest/send-data/promtail/installation/
+--- # Daemonset.yaml
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: promtail-daemonset
+spec:
+  selector:
+    matchLabels:
+      name: promtail
+  template:
+    metadata:
+      labels:
+        name: promtail
+    spec:
+      serviceAccount: promtail-serviceaccount
+      initContainers:
+      - name: replace-loki-endpoint
+        image: ubuntu:22.04
+        commands: ["bash", "-c", "cat /etc/promtail/loki-endpoint && cat /etc/promtail/promtail.yaml && sed -i /etc/promtail \"s/LOKI_ENDPOINT/$(cat /etc/promtail/loki-endpoint)\""]
+        volumeMounts:
+        - name: promtail-config
+          mountPath: /etc/promtail
+        - mountPath: /etc/promtail
+          name: loki-endpoint
+          readOnly: true
+      containers:
+      - name: promtail-container
+        image: grafana/promtail
+        args:
+        - -config.file=/etc/promtail/promtail.yaml
+        env: 
+        - name: 'HOSTNAME' # needed when using kubernetes_sd_configs
+          valueFrom:
+            fieldRef:
+              fieldPath: 'spec.nodeName'
+        volumeMounts:
+        - name: logs
+          mountPath: /var/log
+        - name: promtail-config
+          mountPath: /etc/promtail
+        - mountPath: /var/lib/docker/containers
+          name: varlibdockercontainers
+          readOnly: true
+        - mountPath: /etc/promtail
+          name: loki-endpoint
+          readOnly: true
+      volumes:
+      - name: logs
+        hostPath:
+          path: /var/log
+      - name: varlibdockercontainers
+        hostPath:
+          path: /var/lib/docker/containers
+      - name: promtail-config
+        configMap:
+          name: promtail-config
+      - name: loki-endpoint
+        secret:
+          name: loki-endpoint
+--- # configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: promtail-config
+data:
+  promtail.yaml: |
+    server:
+      http_listen_port: 9080
+      grpc_listen_port: 0
+
+    clients:
+    - url: https://LOKI_ENDPOINT/loki/api/v1/push
+
+    positions:
+      filename: /tmp/positions.yaml
+    target_config:
+      sync_period: 10s
+    scrape_configs:
+    - job_name: pod-logs
+      kubernetes_sd_configs:
+        - role: pod
+      pipeline_stages:
+        - docker: {}
+      relabel_configs:
+        - source_labels:
+            - __meta_kubernetes_pod_node_name
+          target_label: __host__
+        - action: labelmap
+          regex: __meta_kubernetes_pod_label_(.+)
+        - action: replace
+          replacement: $1
+          separator: /
+          source_labels:
+            - __meta_kubernetes_namespace
+            - __meta_kubernetes_pod_name
+          target_label: job
+        - action: replace
+          source_labels:
+            - __meta_kubernetes_namespace
+          target_label: namespace
+        - action: replace
+          source_labels:
+            - __meta_kubernetes_pod_name
+          target_label: pod
+        - action: replace
+          source_labels:
+            - __meta_kubernetes_pod_container_name
+          target_label: container
+        - replacement: /var/log/pods/*$1/*.log
+          separator: /
+          source_labels:
+            - __meta_kubernetes_pod_uid
+            - __meta_kubernetes_pod_container_name
+          target_label: __path__
+
+--- # Clusterrole.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: promtail-clusterrole
+rules:
+  - apiGroups: [""]
+    resources:
+    - nodes
+    - services
+    - pods
+    verbs:
+    - get
+    - watch
+    - list
+
+--- # ServiceAccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: promtail-serviceaccount
+
+--- # Rolebinding.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: promtail-clusterrolebinding
+subjects:
+    - kind: ServiceAccount
+      name: promtail-serviceaccount
+      namespace: default
+roleRef:
+    kind: ClusterRole
+    name: promtail-clusterrole
+    apiGroup: rbac.authorization.k8s.io

--- a/k8s/system/manifests/promtail/promtail.yaml
+++ b/k8s/system/manifests/promtail/promtail.yaml
@@ -17,7 +17,7 @@ spec:
       initContainers:
       - name: replace-loki-endpoint
         image: ubuntu:22.04
-        commands: ["sed", "\"s/LOKI_ENDPOINT/$(cat /etc/loki/loki-endpoint)/\"", "/etc/promtail/promtail.yaml"]
+        commands: ["sed", "-i", "\"s/LOKI_ENDPOINT/$(cat /etc/loki/loki-endpoint)/\"", "/etc/promtail/promtail.yaml"]
         volumeMounts:
         - name: promtail-config
           mountPath: /etc/promtail

--- a/k8s/system/manifests/promtail/promtail.yaml
+++ b/k8s/system/manifests/promtail/promtail.yaml
@@ -17,10 +17,11 @@ spec:
       initContainers:
       - name: replace-loki-endpoint
         image: ubuntu:22.04
-        commands: ["bash", "-c", "\"sed -i /etc/promtail/promtail.yaml 's/$(cat /etc/loki/loki-endpoint)/foobar/\""]
+        commands: ["sed", "\"s/LOKI_ENDPOINT/$(cat /etc/loki/loki-endpoint)/\"", "/etc/promtail/promtail.yaml"]
         volumeMounts:
         - name: promtail-config
           mountPath: /etc/promtail
+          readOnly: false
         - mountPath: /etc/loki
           name: loki-endpoint
           readOnly: true
@@ -39,6 +40,7 @@ spec:
           mountPath: /var/log
         - name: promtail-config
           mountPath: /etc/promtail
+          readOnly: false
         - mountPath: /var/lib/docker/containers
           name: varlibdockercontainers
           readOnly: true

--- a/k8s/system/manifests/promtail/promtail.yaml
+++ b/k8s/system/manifests/promtail/promtail.yaml
@@ -20,7 +20,7 @@ spec:
         commands: ["bash", "-c", "mkdir /etc/promtail && touch /etc/promtail/promtail.yaml && sed \"s/LOKI_ENDPOINT/$(cat /etc/loki/loki-endpoint)/\" /etc/setup/promtail.yaml > /etc/promtail/promtail.yaml"]
         volumeMounts:
         - name: promtail-config
-          mountPath: /etc/promtail
+          mountPath: /etc/setup
         - mountPath: /etc/loki
           name: loki-endpoint
           readOnly: true

--- a/k8s/system/manifests/promtail/promtail.yaml
+++ b/k8s/system/manifests/promtail/promtail.yaml
@@ -17,7 +17,7 @@ spec:
       initContainers:
       - name: replace-loki-endpoint
         image: ubuntu:22.04
-        commands: ["bash", "-c", "touch /etc/promtail/promtail.yaml && ls /etc/loki && ls /etc/setup && ls /etc/promtail && sed \"s/LOKI_ENDPOINT/$(cat /etc/loki/loki-endpoint)/\" /etc/setup/promtail.yaml > /etc/promtail/promtail.yaml"]
+        command: ["bash", "-c", "touch /etc/promtail/promtail.yaml && ls /etc/loki && ls /etc/setup && ls /etc/promtail && sed \"s/LOKI_ENDPOINT/$(cat /etc/loki/loki-endpoint)/\" /etc/setup/promtail.yaml > /etc/promtail/promtail.yaml"]
         volumeMounts:
         - name: promtail-config
           mountPath: /etc/setup

--- a/k8s/system/manifests/promtail/promtail.yaml
+++ b/k8s/system/manifests/promtail/promtail.yaml
@@ -17,11 +17,10 @@ spec:
       initContainers:
       - name: replace-loki-endpoint
         image: ubuntu:22.04
-        commands: ["sed", "-i", "\"s/LOKI_ENDPOINT/$(cat /etc/loki/loki-endpoint)/\"", "/etc/promtail/promtail.yaml"]
+        commands: ["bash", "-c", "mkdir /etc/promtail && touch /etc/promtail/promtail.yaml && sed \"s/LOKI_ENDPOINT/$(cat /etc/loki/loki-endpoint)/\" /etc/setup/promtail.yaml > /etc/promtail/promtail.yaml"]
         volumeMounts:
         - name: promtail-config
           mountPath: /etc/promtail
-          readOnly: false
         - mountPath: /etc/loki
           name: loki-endpoint
           readOnly: true
@@ -39,8 +38,7 @@ spec:
         - name: logs
           mountPath: /var/log
         - name: promtail-config
-          mountPath: /etc/promtail
-          readOnly: false
+          mountPath: /etc/setup
         - mountPath: /var/lib/docker/containers
           name: varlibdockercontainers
           readOnly: true

--- a/k8s/system/manifests/promtail/promtail.yaml
+++ b/k8s/system/manifests/promtail/promtail.yaml
@@ -57,7 +57,7 @@ spec:
           name: promtail-config
       - name: loki-endpoint
         secret:
-          name: loki-endpoint
+          secretName: loki-endpoint
 --- # configmap.yaml
 apiVersion: v1
 kind: ConfigMap

--- a/k8s/system/manifests/promtail/promtail.yaml
+++ b/k8s/system/manifests/promtail/promtail.yaml
@@ -17,7 +17,7 @@ spec:
       initContainers:
       - name: replace-loki-endpoint
         image: ubuntu:22.04
-        commands: ["bash", "-c", "sed -i /etc/promtail/promtail.yaml 's/LOKI_ENDPOINT/foobar/"]
+        commands: ["bash", "-c", "\"sed -i /etc/promtail/promtail.yaml 's/$(cat /etc/loki/loki-endpoint)/foobar/\""]
         volumeMounts:
         - name: promtail-config
           mountPath: /etc/promtail

--- a/k8s/system/manifests/promtail/promtail.yaml
+++ b/k8s/system/manifests/promtail/promtail.yaml
@@ -154,7 +154,7 @@ metadata:
 subjects:
     - kind: ServiceAccount
       name: promtail-serviceaccount
-      namespace: default
+      namespace: promtail
 roleRef:
     kind: ClusterRole
     name: promtail-clusterrole

--- a/k8s/system/manifests/promtail/promtail.yaml
+++ b/k8s/system/manifests/promtail/promtail.yaml
@@ -17,7 +17,7 @@ spec:
       initContainers:
       - name: replace-loki-endpoint
         image: ubuntu:22.04
-        commands: ["bash", "-c", "cat /etc/loki/loki-endpoint && cat /etc/promtail/promtail.yaml && sed -i /etc/promtail \"s/LOKI_ENDPOINT/$(cat /etc/loki/loki-endpoint)\""]
+        commands: ["bash", "-c", "cat /etc/loki/loki-endpoint && cat /etc/promtail/promtail.yaml && sed -i /etc/promtail/promtail.yaml \"s/LOKI_ENDPOINT/$(cat /etc/loki/loki-endpoint)\""]
         volumeMounts:
         - name: promtail-config
           mountPath: /etc/promtail

--- a/k8s/system/templates/promtail.yaml
+++ b/k8s/system/templates/promtail.yaml
@@ -1,0 +1,22 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: promtail
+  namespace: {{ .Values.metadata.namespace }}
+  finalizers:
+  - resources-finalizer.argocd.argoproj.io
+spec:
+  destination:
+    namespace: promtail
+    server: {{ .Values.spec.destination.server }}
+  project: {{ .Values.spec.project }}
+  sources:
+  - path: k8s/system/manifests/promtail
+    repoURL: {{ .Values.spec.source.repoURL }}
+    targetRevision: {{ .Values.global.charts_version }}
+  syncPolicy:
+    syncOptions:
+    - CreateNamespace=true
+    automated:
+      selfHeal: true
+      prune: true


### PR DESCRIPTION
https://github.com/furon-kuina/furonverse/issues/13
Lokiは以下の理由からGrafana Cloudに託し、Promtailでpushする形に決定。
1. クラスタが死んでもログは確認したい
2. Cloudflareなどクラスタ以外からのログも集約したい（やろうと思えばローカルでもできるけど）
3. ストレージはできるだけ自分で管理したくない