### PR TITLE
外形監視用のGCEインスタンスを作成

### DIFF
--- a/gcp/main.tf
+++ b/gcp/main.tf
@@ -51,3 +51,20 @@ resource "google_project_iam_member" "cluster_image_pull" {
   role    = "roles/artifactregistry.reader"
   member  = "serviceAccount:${google_service_account.cluster.email}"
 }
+
+resource "google_compute_instance" "free_tier" {
+  name = "free-tier"
+  machine_type = "e2-micro"
+  zone = "us-west1-a"
+  boot_disk {
+    initialize_params {
+      image = "debian-12-bookworm-v20250212"
+      size = "30"
+      type = "pd-standard"
+    }
+  }
+  network_interface {
+    network = "default"
+    access_config {}
+  }
+}

--- a/gcp/main.tf
+++ b/gcp/main.tf
@@ -53,14 +53,14 @@ resource "google_project_iam_member" "cluster_image_pull" {
 }
 
 resource "google_compute_instance" "free_tier" {
-  name = "free-tier"
+  name         = "free-tier"
   machine_type = "e2-micro"
-  zone = "us-west1-a"
+  zone         = "us-west1-a"
   boot_disk {
     initialize_params {
       image = "debian-12-bookworm-v20250212"
-      size = "30"
-      type = "pd-standard"
+      size  = "30"
+      type  = "pd-standard"
     }
   }
   network_interface {


### PR DESCRIPTION
Uptime Kumaは外形監視なのでクラスタ外に置いておきたい。
それを動かしておく無料枠のインスタンスを作成した。
